### PR TITLE
[PAL/vm-common] vsock: fix host-side vsock buf management

### DIFF
--- a/pal/src/host/vm-common/kernel_virtio.h
+++ b/pal/src/host/vm-common/kernel_virtio.h
@@ -313,11 +313,6 @@ struct virtio_vsock_config {
  *   - tq_notify_addr is set at init and used in copy_into_tq(), sync via transmit-side lock
  *   - host_cid is set at init, no sync required
  *   - guest_cid is set at init, no sync required
- *   - peer_fwd_cnt and peer_buffer_alloc are used by CPU0-tied bottomhalves thread during RX,
- *     sync via receive-side lock
- *   - fwd_cnt and msg_cnt are used during RX and TX, must be accessed via atomic ops
- *   - buf_alloc is set at init, no sync required
- *   - tx_cnt is used in copy_into_tq(), sync via transmit-side lock
  *   - conns_size, conns, conns_by_host_port used in many places, sync via connections lock
  *   - pending_tq_control_packets and co. used during TX, sync via transmit-side lock
  *   - shared_rq_buf is set at init and used during RX, sync via receive-side lock
@@ -336,14 +331,6 @@ struct virtio_vsock {
 
     uint64_t host_cid;
     uint64_t guest_cid;
-
-    uint32_t peer_fwd_cnt;   /* total bytes received by host on tq */
-    uint32_t peer_buf_alloc; /* total buffer space on host */
-    uint32_t fwd_cnt;        /* total bytes received by guest on rq */
-    uint32_t buf_alloc;      /* total buffer space on guest */
-
-    uint32_t tx_cnt;         /* total bytes sent by guest on tq */
-    uint32_t msg_cnt;        /* total number of received msgs */
 
     uint32_t conns_size;                    /* size of dynamic array */
     struct virtio_vsock_connection** conns; /* dynamic array: fd -> connection */

--- a/pal/src/host/vm-common/kernel_virtio_vsock.h
+++ b/pal/src/host/vm-common/kernel_virtio_vsock.h
@@ -135,6 +135,15 @@ struct virtio_vsock_connection {
     uint32_t prepared_for_user;
     uint32_t consumed_by_user;
 
+    /* per-connection (per-socket) buffer space management: guest side, not used currently */
+    uint32_t tx_cnt;         /* free-running counter: bytes transmitted to host */
+    uint32_t peer_fwd_cnt;   /* free-running counter: bytes received by host */
+    uint32_t peer_buf_alloc; /* buffer space for this connection on host */
+
+    /* per-connection (per-socket) buffer space management: host side, must inform host */
+    uint32_t fwd_cnt;        /* free-running counter: bytes received by this guest */
+    uint32_t buf_alloc;      /* buffer space for this connection on this guest */
+
     /* receive/send is disallowed on this connection (depends on received SHUTDOWN requests) */
     bool recv_disallowed;
     bool send_disallowed;


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

The host uses `fwd_cnt` and `buf_alloc` obtained in the guest's vsock packets for its buffer management (deciding whether to send a next packet to guest or back off). We previously incorrectly implemented this by making the two variables global for all virtual sockets. In reality, these variables are per-connection (per-socket). This mismatch between what the host expects and what Gramine guest implements led to hangs because on new connections, Gramine reported too many "bytes received" in `fwd_cnt` counter, leading the host to believe there are too many packets in flight on the new connection and to back off constantly.

Fix by moving the vars to fields of `struct virtio_vsock_connection`. An additional benefit is that we already have proper locking for per-connection fields, so there is no need for atomics or special synchronization.

Interestingly, Linux prior to v6.7 did not expose this Gramine bug because it itself had a bug of integer wrap around. This was fixed with commit https://github.com/torvalds/linux/commit/60316d7f10b17a in v6.7.

Fixes #24.

## How to test this PR? <!-- (if applicable) -->

Run Redis or Memcached on Linux v6.7 or higher. I tested on v6.9.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine-tdx/25)
<!-- Reviewable:end -->
