### PR TITLE
[PAL/vm-common] Get memory regions from VMM using "etc/e820" fw_cfg file

### DIFF
--- a/pal/src/host/vm-common/kernel_memory.c
+++ b/pal/src/host/vm-common/kernel_memory.c
@@ -437,6 +437,12 @@ int memory_preload_ranges(e820_table_entry* e820_entries, size_t e820_entries_si
         if (e820_entries[i].type == E820_ADDRESS_RANGE_MEMORY)
             continue;
 
+        if (PCI_HOLE_ADDR <= e820_entries[i].address &&
+                e820_entries[i].address + e820_entries[i].size <= PCI_HOLE_ADDR + PCI_HOLE_SIZE) {
+            /* reported reserved memory region is fully consumed by the PCI hole region */
+            continue;
+        }
+
         if (e820_entries[i].address < PAGE_TABLES_ADDR + PAGE_TABLES_SIZE &&
                 PAGE_TABLES_ADDR < e820_entries[i].address + e820_entries[i].size) {
             /* a reserved range overlaps with our page tables range */
@@ -483,7 +489,7 @@ int memory_preload_ranges(e820_table_entry* e820_entries, size_t e820_entries_si
     ret = callback(SHARED_MEM_ADDR, SHARED_MEM_SIZE, "shared_memory");
     if (ret < 0)
         return -PAL_ERROR_NOMEM;
-    ret = callback(0x80000000UL, 0x80000000UL, "qemu_pci_hole");
+    ret = callback(PCI_HOLE_ADDR, PCI_HOLE_SIZE, "qemu_pci_hole");
     if (ret < 0)
         return -PAL_ERROR_NOMEM;
 

--- a/pal/src/host/vm-common/kernel_memory.h
+++ b/pal/src/host/vm-common/kernel_memory.h
@@ -14,6 +14,9 @@
 #define SHARED_MEM_ADDR  0x29200000UL          /* shared memory occupies [658MB, 896MB) */
 #define SHARED_MEM_SIZE  (238UL * 1024 * 1024) /* 238MB */
 
+#define PCI_HOLE_ADDR    0x80000000UL          /* QEMU's memory hole + PCI (BARs, LAPIC, IOAPIC) */
+#define PCI_HOLE_SIZE    0x80000000UL          /* 2GB */
+
 /* equivalent to E820_TABLE_ENTRY in EFI_HOB_E820_TABLE (needs to be packed) */
 #define E820_ADDRESS_RANGE_MEMORY   1
 #define E820_ADDRESS_RANGE_RESERVED 2
@@ -22,6 +25,11 @@ typedef struct {
     uint64_t  size;
     uint32_t  type;
 } __attribute__((packed)) e820_table_entry;
+
+/* max number of entries in the E820 table; taken from QEMU sources */
+#define E820_NR_ENTRIES 16
+
+#define E820_TABLE_MAX_SIZE (E820_NR_ENTRIES * sizeof(e820_table_entry))
 
 extern uint64_t g_pml4_table_base;
 

--- a/pal/src/host/vm-common/kernel_vmm_inputs.h
+++ b/pal/src/host/vm-common/kernel_vmm_inputs.h
@@ -2,17 +2,24 @@
 /* Copyright (C) 2023 Intel Corporation */
 
 /*
- * Read inputs from VMM. Currently three inputs:
+ * Read inputs from VMM. Currently the following inputs:
  * - Command-line arguments
  * - Host environment variables
  * - PWD (host's current working directory)
+ * - initial UNIX time
+ * - E820 table of VMM-reserved memory ranges (only for VM PAL; TDX PAL uses TDX hobs)
  *
- * Gramine command-line args and host environment variables are read from fw_cfg QEMU pseudo-device.
- * They are supposed to be put in one of the selectors above 0x19 and be in a special format (see
- * below).
+ * Gramine command-line args, host environment variables, PWD, and initial UNIX time are all read
+ * from fw_cfg QEMU pseudo-device. They are supposed to be put in one of the selectors above 0x19
+ * and be in a special format (see below).
+ *
+ * The E820 table is also read from fw_cfg QEMU pseudo-device and uses the hard-coded selector
+ * "etc/e820" (file). Note that another selector FW_CFG_E820_TABLE was deprecated since QEMU v7.2.
  *
  * The selector with command-line args has the name "opt/gramine/args".
  * The selector with environment variables has the name "opt/gramine/envs".
+ * The selector with PWD has the name "opt/gramine/pwd".
+ * The selector with initial UNIX time has the name "opt/gramine/unixtime_s".
  *
  * For details, see:
  *   - qemu.org/docs/master/specs/fw_cfg.html
@@ -76,3 +83,5 @@ int cmdline_read_gramine_envs(const char* envs, int* out_envp_cnt, const char** 
 int cmdline_init_envs(char* cmdline_envs, size_t cmdline_envs_size);
 
 int unixtime_init(char* unixtime_s, size_t unixtime_size);
+
+int e820_table_init(char* e820_table, size_t* e820_size, size_t max_e820_size);


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously on the VM PAL, we hard-coded a single memory region that is RAM (i.e., not reserved) via `FW_CFG_RAM_SIZE`. This is a dangerous assumption which may break in the future. This commit uses a proper source of E820 info: the `etc/e820` fw_cfg file.

As a side effect, `find_fw_cfg_selector()` function was slightly modified to also return the size of the object. All callers of this function now use this returned size.

Fixes #27.

## How to test this PR? <!-- (if applicable) -->

Run on newer QEMU.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine-tdx/28)
<!-- Reviewable:end -->
