### PR TITLE
[PAL/vm-common,TDX] Fix nasm warning on ambiguous operand size

### DIFF
--- a/pal/src/host/tdx/pal_bootloader.S
+++ b/pal/src/host/tdx/pal_bootloader.S
@@ -58,7 +58,7 @@ pal_start:
 
     // jump to pal_start_c() entrypoint, together with setting the CS segment register
     lea     pal_start_c(%rip), %rax
-    push    $(_gdt_entry_kernel_cs - _gdt_start)
+    pushq   $(_gdt_entry_kernel_cs - _gdt_start)
     push    %rax
     lretq
 

--- a/pal/src/host/vm-common/kernel_multicore64.S
+++ b/pal/src/host/vm-common/kernel_multicore64.S
@@ -63,7 +63,7 @@ ap_startup_page_start:
 
     // jump to pal_start_ap_c() entrypoint, together with setting the CS segment register
     mov     AP_STARTUP_PAGE_C_FUNC, %rax
-    push    $(_gdt_entry_kernel_cs - _gdt_start)
+    pushq   $(_gdt_entry_kernel_cs - _gdt_start)
     push    %rax
     lretq
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Newer nasm (2.17rc0) complains about ambiguous operand size on asm like `push $123`. That's because the default operand size is 32 bits even in 64-bit mode. Thus, we need an explicit operand-size suffix: `pushq`.

## How to test this PR? <!-- (if applicable) -->

Build with new nasm.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine-tdx/29)
<!-- Reviewable:end -->
