### PR TITLE
[tools] Fix `memory-backend` arg in QEMU cmdline in `gramine-vm.in`

### DIFF
--- a/tools/gramine-vm.in
+++ b/tools/gramine-vm.in
@@ -91,9 +91,9 @@ QEMU_CPU_NUM=${QEMU_CPU_NUM:-"1"}
 QEMU_PATH="qemu"
 QEMU_VM="-cpu host,host-phys-bits,-kvm-steal-time,pmu=off,+tsc-deadline,+invtsc \
     -m $QEMU_MEM_SIZE -smp $QEMU_CPU_NUM"
-QEMU_OPTS="-enable-kvm -vga none -display none -no-reboot -monitor none -machine hpet=off \
-    -object memory-backend-file,id=mem,size=$QEMU_MEM_SIZE,mem-path=/dev/shm,share=on \
-    -numa node,memdev=mem"
+QEMU_OPTS="-enable-kvm -vga none -display none -no-reboot -monitor none \
+    -object memory-backend-memfd,id=mem,size=$QEMU_MEM_SIZE,private=on \
+    -M memory-backend=mem,hpet=off"
 
 if [ "$TDSHIM_PAL_PATH" == "" ]; then
 QEMU_MACHINE="-M q35,kernel_irqchip=split"


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Newer QEMU version (v8.0.4 patched for TDX) shipped with Ubuntu 23.10 (Canonical TDX-enlightened version) changed requirements on the QEMU cmdline. In particular, newer versions of virtiofsd (that Gramine-TDX uses for sharing files) require `-object memory-backend-memfd,...` and QEMU requires `-object memory-backend-memfd,...,private=on` (note `private=on`, without it QEMU/KVM complains about ENCRYPT_OPs).

Also see notes in https://github.com/gramineproject/gramine-tdx/discussions/14#discussioncomment-10006771.

## How to test this PR? <!-- (if applicable) -->

Run `gramine-tdx helloworld`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine-tdx/30)
<!-- Reviewable:end -->
