### PR TITLE
[PAL/vm-common] Fix undefined behavior in `find_fw_cfg_selector()`

### DIFF
--- a/pal/src/host/vm-common/kernel_vmm_inputs.c
+++ b/pal/src/host/vm-common/kernel_vmm_inputs.c
@@ -130,11 +130,15 @@ int cmdline_read_gramine_envs(const char* envs, int* out_envp_cnt, const char** 
 
 static int find_fw_cfg_selector(const char* fw_cfg_name, uint16_t* out_selector,
                                 uint32_t* out_size) {
-    uint32_t fw_cfg_files_count = 0;
-    uint8_t* fw_cfg_files_count_raw = (uint8_t*)&fw_cfg_files_count;
+    uint32_t fw_cfg_files_count;
+
+    uint8_t fw_cfg_files_count_raw[4];
     vm_portio_writew(FW_CFG_PORT_SEL, FW_CFG_FILE_DIR);
     for (size_t i = 0; i < sizeof(fw_cfg_files_count); i++)
         fw_cfg_files_count_raw[i] = vm_portio_readb(FW_CFG_PORT_SEL + 1);
+    fw_cfg_files_count = fw_cfg_files_count_raw[0] + (fw_cfg_files_count_raw[1] << 8)
+                                                   + (fw_cfg_files_count_raw[2] << 16)
+                                                   + (fw_cfg_files_count_raw[3] << 24);
 
     /* QEMU provides in big-endian, but our x86-64 CPU is little-endian */
     fw_cfg_files_count = __builtin_bswap32(fw_cfg_files_count);


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, `find_fw_cfg_selector()` had a UB: the main variable `uint32_t fw_cfg_files_count` was aliased by the 4-bytes array `uint8_t fw_cfg_files_count_raw[4]`. This was done for ease of port I/O, since only byte-sized port I/O is used for FW_CFG device. The hope was that updating bytes in `fw_cfg_files_count_raw` would transparently update the main variable. However, this is UB, and GCC build with optimizations (i.e., in the release mode) assumed that the main variable `fw_cfg_files_count` is not updated and is still zero, which led to incorrect result of the function, which ultimately led to abnormal termination of the VM in the early stages.

## How to test this PR? <!-- (if applicable) -->

Build in release mode.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine-tdx/33)
<!-- Reviewable:end -->
