### PR TITLE
[tools] Fix QEMU args in `gramine-vm.in`

### DIFF
--- a/tools/gramine-vm.in
+++ b/tools/gramine-vm.in
@@ -92,7 +92,7 @@ QEMU_PATH="qemu"
 QEMU_VM="-cpu host,host-phys-bits,-kvm-steal-time,pmu=off,+tsc-deadline,+invtsc \
     -m $QEMU_MEM_SIZE -smp $QEMU_CPU_NUM"
 QEMU_OPTS="-enable-kvm -vga none -display none -no-reboot -monitor none \
-    -object memory-backend-memfd,id=mem,size=$QEMU_MEM_SIZE,private=on \
+    -object memory-backend-memfd,id=mem,size=$QEMU_MEM_SIZE \
     -M memory-backend=mem,hpet=off"
 
 if [ "$TDSHIM_PAL_PATH" == "" ]; then
@@ -100,7 +100,7 @@ QEMU_MACHINE="-M q35,kernel_irqchip=split"
 QEMU_BINARIES="-kernel $LIBPAL_PATH -device loader,file=$BIOS_PATH"
 else
 QEMU_MACHINE="-M q35,kernel_irqchip=split,confidential-guest-support=tdx \
-    -object tdx-guest,id=tdx,quote-generation-service=vsock:2:4050"
+    -object tdx-guest,id=tdx"
 QEMU_BINARIES="-bios $TDSHIM_PAL_PATH"
 fi
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

QEMU arguments changed a bit in v8.2.1 (used in Ubuntu 24.04). Adjust them in the `gramine-tdx` wrapper script.

@dimstav23 helped detecting these issues. Kudos to him.

## How to test this PR? <!-- (if applicable) -->

Run `gramine-tdx` under Ubuntu 24.04 and QEMU 8.2.1.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine-tdx/35)
<!-- Reviewable:end -->
