### PR TITLE
[LibOS] Rewire RIP of to-save and to-restore contexts for VM PALs

### DIFF
--- a/pal/include/pal/pal.h
+++ b/pal/include/pal/pal.h
@@ -157,6 +157,11 @@ struct pal_public_state {
     size_t initial_mem_ranges_len;
 
     /*
+     * App context on syscall
+     */
+    uint64_t vm_user_rip_offset;
+
+    /*
      * Host information
      */
 

--- a/pal/src/host/tdx/pal_main.c
+++ b/pal/src/host/tdx/pal_main.c
@@ -447,6 +447,9 @@ noreturn int pal_start_continue(void* cmdline_) {
 
     g_pal_public_state.attestation_type = "dcap";
 
+    g_pal_public_state.vm_user_rip_offset = offsetof(struct pal_tcb_vm,
+                                                     kernel_thread.context.user_rip);
+
     ret = pal_common_get_topo_info(&g_pal_public_state.topo_info);
     if (ret < 0)
         INIT_FAIL("Failed to get topology information: %s", pal_strerror(ret));

--- a/pal/src/host/vm/pal_main.c
+++ b/pal/src/host/vm/pal_main.c
@@ -347,6 +347,9 @@ noreturn int pal_start_continue(void* cmdline_) {
 
     g_pal_public_state.attestation_type = "none";
 
+    g_pal_public_state.vm_user_rip_offset = offsetof(struct pal_tcb_vm,
+                                                     kernel_thread.context.user_rip);
+
     ret = pal_common_get_topo_info(&g_pal_public_state.topo_info);
     if (ret < 0)
         INIT_FAIL("Failed to get topology information: %s", pal_strerror(ret));


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, the LibOS logic had two places that assumed ring-3 environment and did not account for the need to execute `sysret`:
- Preparing sigframes for the application signal handler; the interrupted app context is saved in the sigframe.
- Performing `rt_sigreturn()` syscall after the application signal handler is done; the app context is restored from the previously-saved sigframe.

In case of VM-based PALs, where LibOS runs in ring-0 and app runs in ring-3, there is a wrapper around syscall enter/exit, see `syscall_asm` and `sysret_asm` in vm-common/kernel_events.S file. This wrapper rewires the context RIP: upon syscall entry, it saves the app context RIP into a TCB-local variable and sets RIP to the address of the `sysret_asm` routine, and upon syscall exit, it restores app context RIP from the TCB-local variable.

This wrapper rewiring was not accounted for in the LibOS logic, meaning that the LibOS would prepare the sigframe with RIP not of the app context but of the `sysret_asm` routine. Similarly, the LibOS would restore not the app context's RIP but the RIP of `sysret_asm`. This commit adds VM PAL-specific RIP fixups to the LibOS logic.

For additional, though not strictly related context, see https://github.com/gramineproject/gramine-tdx/issues/23

## How to test this PR? <!-- (if applicable) -->

Run any Go app that uses lightweight threads.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine-tdx/36)
<!-- Reviewable:end -->
