### PR TITLE
[PAL/vm-common] Add rt_sigreturn return-to-userspace flow

### DIFF
--- a/pal/src/host/vm-common/generated_offsets.c
+++ b/pal/src/host/vm-common/generated_offsets.c
@@ -4,11 +4,14 @@
 
 #include "kernel_multicore.h"
 #include "kernel_sched.h"
+#include "kernel_syscalls.h"
 #include "kernel_xsave.h"
 
 const char* generated_offsets_name = "PAL_VM";
 
 const struct generated_offset generated_offsets[] = {
+    DEFINE(SYSCALL_RT_SIGRETURN, SYSCALL_RT_SIGRETURN),
+
     DEFINE(VM_XSAVE_ALIGN, VM_XSAVE_ALIGN),
     DEFINE(MSR_IA32_GS_BASE, MSR_IA32_GS_BASE),
     DEFINE(MSR_IA32_GS_KERNEL_BASE, MSR_IA32_GS_KERNEL_BASE),
@@ -25,6 +28,10 @@ const struct generated_offset generated_offsets[] = {
     /* struct pal_tcb_vm */
     OFFSET(PAL_TCB_LIBOS, pal_tcb_vm, common.libos_tcb),
     OFFSET(PAL_TCB_VM_USER_RIP, pal_tcb_vm, kernel_thread.context.user_rip),
+
+    OFFSET(PAL_TCB_VM_SIGRETURN_USER_RSP, pal_tcb_vm, kernel_thread.sigreturn_user_rsp),
+    OFFSET(PAL_TCB_VM_SIGRETURN_USER_RAX, pal_tcb_vm, kernel_thread.sigreturn_user_rax),
+    OFFSET(PAL_TCB_VM_SIGRETURN_PSEUDO_RSP, pal_tcb_vm, kernel_thread.sigreturn_pseudo_rsp),
 
     OFFSET(PAL_TCB_VM_CONTEXT_R8, pal_tcb_vm, kernel_thread.context.r8),
     OFFSET(PAL_TCB_VM_CONTEXT_R9, pal_tcb_vm, kernel_thread.context.r9),

--- a/pal/src/host/vm-common/kernel_events.S
+++ b/pal/src/host/vm-common/kernel_events.S
@@ -138,7 +138,14 @@ jump_into_user_mode:
 // FIXME: ideally must add swapgs in the very beginning, but GS is not used by ring-3 anyway
 syscall_asm:
     mov     %rcx, %gs:PAL_TCB_VM_USER_RIP
+    cmp     $SYSCALL_RT_SIGRETURN, %rax
+    je      .Linstall_rt_sigreturn_path
+.Linstall_sysret_path:
     lea     sysret_asm(%rip), %rcx
+    jmp     .Lsyscall_libos
+.Linstall_rt_sigreturn_path:
+    lea     sigreturn_asm(%rip), %rcx
+.Lsyscall_libos:
     jmp     *%gs:(PAL_TCB_LIBOS + 0x8)      // `libos_syscall_entry` addr is at offset 0x8
 
 // FIXME: ideally must add swapgs right-before sysretq, but GS is not used by ring-3 anyway
@@ -146,6 +153,34 @@ sysret_asm:
     mov     %gs:PAL_TCB_VM_USER_RIP, %rcx
     or      $0x200, %r11                    // userland RFLAGS will contain IF
     sysretq
+
+// FIXME: ideally must add swapgs right-before sysretq, but GS is not used by ring-3 anyway
+sigreturn_asm:
+    // memorize user RSP because need to switch to pseudo stack for iretq
+    mov     %rsp, %gs:PAL_TCB_VM_SIGRETURN_USER_RSP
+    // memorize user RAX because need one temporary register to push values to pseudo stack
+    mov     %rax, %gs:PAL_TCB_VM_SIGRETURN_USER_RAX
+
+    mov     %gs:PAL_TCB_VM_SIGRETURN_PSEUDO_RSP, %rsp
+    // push SS: 64-bit user data
+    pushq   $0x23 // SS segment selector: Index=100 (4), GDT, RPL=11
+    // push user RSP
+    mov     %gs:PAL_TCB_VM_SIGRETURN_USER_RSP, %rax
+    push    %rax
+    // push user RFLAGS; make sure it contains IF
+    pushfq
+    pop     %rax
+    or      $0x200, %rax
+    push    %rax
+    // push CS: 64-bit user code
+    pushq   $0x2b // CS segment selector: Index=101 (5), GDT, RPL=11
+    // push user RIP
+    mov     %gs:PAL_TCB_VM_USER_RIP, %rax
+    push    %rax
+    // RSP will be restored by iretq, but RAX we must restore manually
+    mov     %gs:PAL_TCB_VM_SIGRETURN_USER_RAX, %rax
+    // jump to user context
+    iretq
 
 
     // void save_context_and_restore_next(uint64_t curr_gs_base, uint64_t next_gs_base,

--- a/pal/src/host/vm-common/kernel_syscalls.h
+++ b/pal/src/host/vm-common/kernel_syscalls.h
@@ -11,4 +11,7 @@
 #define MSR_LSTAR        0xc0000082 /* target 64-bit RIP on `syscall` instruction */
 #define MSR_SYSCALL_MASK 0xc0000084 /* RFLAGS mask to apply on `syscall` instruction */
 
+/* rt_sigreturn has a special return-from-syscall path, see kernel_events.S */
+#define SYSCALL_RT_SIGRETURN 15
+
 int syscalls_init(void);

--- a/pal/src/host/vm-common/kernel_thread.c
+++ b/pal/src/host/vm-common/kernel_thread.c
@@ -146,6 +146,11 @@ void thread_setup(struct thread* thread, void* fpregs, void* stack, int (*callba
 
     thread->context.rsp -= 8; /* x86-64 calling convention: must be 8-odd at entry */
 
+    /* sigreturn_pseudo_rsp always points at the top of the pseudo stack used in sigreturn flow;
+     * see also kernel_events.S */
+    thread->sigreturn_pseudo_rsp = (uint64_t)&thread->sigreturn_pseudo_stack;
+    thread->sigreturn_pseudo_rsp += sizeof(thread->sigreturn_pseudo_stack);
+
     static uint32_t thread_id = 0;
     thread->thread_id = __atomic_add_fetch(&thread_id, 1, __ATOMIC_SEQ_CST);
 

--- a/pal/src/host/vm-common/kernel_thread.h
+++ b/pal/src/host/vm-common/kernel_thread.h
@@ -83,6 +83,15 @@ struct thread {
     struct thread_context context;
 
     struct thread_irq_pseudo_stack irq_pseudo_stack;
+
+    /* per-thread scratch registers for returning to userspace from rt_sigreturn() syscall;
+     * sigreturn flow is different from normal-return-to-userspace sysret flow in that sigreturn
+     * uses iretq instruction which requires RIP,RSP,RFLAGS to be located on a (pseudo) stack;
+     * see also kernel_events.S */
+    uint64_t sigreturn_user_rsp;
+    uint64_t sigreturn_user_rax;
+    uint64_t sigreturn_pseudo_rsp; /* &sigreturn_pseudo_stack + sizeof(thread_irq_pseudo_stack) */
+    struct thread_irq_pseudo_stack sigreturn_pseudo_stack;
 };
 DEFINE_LISTP(thread);
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

The `rt_sigreturn()` system call has a special return-to-userspace flow. It differs from a normal sysret flow in that `rt_sigreturn()` already prepared the context (including RSP, RFLAGS, etc.) and expects an iretq instruction at the end.

This commit special-cases this sigreturn flow in VM-based PAL assembly. Since the LibOS sigreturn handling already prepared all the context, we must introduce and use per-thread scratch registers to move temporarily to another (pseudo) stack from which the iretq instruction will pop RSP, RFLAGS, RIP, etc.

This change will become important in future commits when support for PF exception handling will be added. In particular, this change is required to run Java workloads (which do #PFs on purpose and then handle the resulting SIGSEGV signal).

## How to test this PR? <!-- (if applicable) -->

When Java workload will start working (need more PRs to add proper #PF exception handling), then run Java.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine-tdx/39)
<!-- Reviewable:end -->
