### PR TITLE
[PAL/vm-common] Add handling of #PF exceptions

### DIFF
--- a/pal/src/host/tdx/pal_exception.c
+++ b/pal/src/host/tdx/pal_exception.c
@@ -10,4 +10,4 @@
 #include "pal_error.h"
 #include "pal_internal.h"
 
-/* currently we don't do anything here */
+/* nothing to do here; all logic is in vm-common/pal_common_exception.c */

--- a/pal/src/host/vm-common/kernel_interrupts.c
+++ b/pal/src/host/vm-common/kernel_interrupts.c
@@ -89,6 +89,13 @@ void isr_c(struct isr_regs* regs) {
             /* below code is currently only for diagnostics; we always panic on PFs */
             uint64_t faulted_addr;
             __asm__ volatile("mov %%cr2, %%rax" : "=a"(faulted_addr));
+
+            ret = pal_common_perform_memfault_handling(faulted_addr, regs);
+            if (ret == 0) {
+                /* LibOS successfully handled the memory fault */
+                break;
+            }
+
             faulted_addr &= ~0xFFFUL;
 
             uint64_t* pte_addr;

--- a/pal/src/host/vm-common/kernel_interrupts.h
+++ b/pal/src/host/vm-common/kernel_interrupts.h
@@ -116,6 +116,8 @@ static inline noreturn void triple_fault(void) {
 
 extern bool g_interrupts_enabled;
 
+int pal_common_perform_memfault_handling(uint64_t faulted_addr, struct isr_regs* regs);
+
 void isr_c(struct isr_regs* regs);
 int send_invalidate_tlb_ipi_and_wait(void* addr, size_t size, bool invalidate_on_this_cpu);
 int interrupts_init(void);

--- a/pal/src/host/vm-common/meson.build
+++ b/pal/src/host/vm-common/meson.build
@@ -23,6 +23,7 @@ pal_vm_common_sources = files(
     'pal_common_console.c',
     'pal_common_eventfd.c',
     'pal_common_events.c',
+    'pal_common_exception.c',
     'pal_common_files.c',
     'pal_common_misc.c',
     'pal_common_object.c',

--- a/pal/src/host/vm-common/pal_common_exception.c
+++ b/pal/src/host/vm-common/pal_common_exception.c
@@ -1,0 +1,92 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2024 Intel Corporation */
+
+/*
+ * This file contains handling of hardware exceptions (forwarding them to LibOS).
+ */
+
+#include "api.h"
+#include "pal.h"
+#include "pal_common.h"
+#include "pal_internal.h"
+
+#include "kernel_interrupts.h"
+
+/* fpregs is shallow copied by only setting a pointer */
+static void isr_regs_to_pal_context(PAL_CONTEXT* context, struct isr_regs* regs,
+                                    uint64_t faulted_addr) {
+    context->r8  = regs->r8;
+    context->r9  = regs->r9;
+    context->r10 = regs->r10;
+    context->r11 = regs->r11;
+    context->r12 = regs->r12;
+    context->r13 = regs->r13;
+    context->r14 = regs->r14;
+    context->r15 = regs->r15;
+    context->rdi = regs->rdi;
+    context->rsi = regs->rsi;
+    context->rbp = regs->rbp;
+    context->rbx = regs->rbx;
+    context->rdx = regs->rdx;
+    context->rax = regs->rax;
+    context->rcx = regs->rcx;
+    context->rsp = regs->rsp;
+    context->rip = regs->rip;
+    context->efl = regs->rflags;
+
+    context->csgsfsss = 0; /* dummy */
+    context->err      = 0; /* dummy */
+    context->trapno   = 0; /* dummy */
+    context->oldmask  = 0; /* dummy */
+    context->cr2      = faulted_addr;
+
+    context->mxcsr    = 0; /* dummy */
+    context->fpcw     = 0; /* dummy */
+
+    context->fpregs = regs->fpregs;
+    context->is_fpregs_used = 1;
+}
+
+/* fpregs is shallow copied by only setting a pointer */
+static void pal_context_to_isr_regs(struct isr_regs* regs, PAL_CONTEXT* context) {
+    regs->r8  = context->r8;
+    regs->r9  = context->r9;
+    regs->r10 = context->r10;
+    regs->r11 = context->r11;
+    regs->r12 = context->r12;
+    regs->r13 = context->r13;
+    regs->r14 = context->r14;
+    regs->r15 = context->r15;
+    regs->rdi = context->rdi;
+    regs->rsi = context->rsi;
+    regs->rbp = context->rbp;
+    regs->rbx = context->rbx;
+    regs->rdx = context->rdx;
+    regs->rax = context->rax;
+    regs->rcx = context->rcx;
+    regs->rsp = context->rsp;
+    regs->rip = context->rip;
+    regs->rflags = context->efl;
+
+    regs->fpregs = context->fpregs;
+}
+
+int pal_common_perform_memfault_handling(uint64_t faulted_addr, struct isr_regs* regs) {
+    pal_event_handler_t upcall = _PalGetExceptionHandler(PAL_EVENT_MEMFAULT);
+    if (!upcall)
+        return -PAL_ERROR_DENIED;
+
+    struct pal_tcb_vm* curr_tcb = (struct pal_tcb_vm*)pal_get_tcb();
+    if (!curr_tcb)
+        return -PAL_ERROR_DENIED;
+
+    /* RIP in the isr_regs is the actual user RIP */
+    curr_tcb->kernel_thread.context.user_rip = regs->rip;
+
+    PAL_CONTEXT context;
+    isr_regs_to_pal_context(&context, regs, faulted_addr);
+    (*upcall)(/*is_in_pal=*/false, faulted_addr, &context);
+    pal_context_to_isr_regs(regs, &context);
+
+    return 0;
+}

--- a/pal/src/host/vm/pal_exception.c
+++ b/pal/src/host/vm/pal_exception.c
@@ -10,4 +10,4 @@
 #include "pal_error.h"
 #include "pal_internal.h"
 
-/* currently we don't do anything here */
+/* nothing to do here; all logic is in vm-common/pal_common_exception.c */


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

In particular, this unblocks Java workloads. This is because Java performs a null pointer dereference on purpose, raising a #PF exception and handling it in an app-level signal handler.

## How to test this PR? <!-- (if applicable) -->

Together with #36, this fully unblocks Java workloads like this one: https://github.com/dimstav23/gramine-examples/tree/dimstav23/add_java_image_processing_example/java_image

Java references that explain when/how Java induces a #PF exception:
- https://github.com/openjdk/jdk/blob/6df7acbc74922d297852044596045a8b32636423/src/hotspot/cpu/x86/vm_version_x86.cpp#L570

- https://github.com/openjdk/jdk/blob/dfacda488bfbe2e11e8d607a6d08527710286982/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp#L246
- https://github.com/openjdk/jdk/blob/890adb6410dab4606a4f26a942aed02fb2f55387/src/hotspot/os/posix/signals_posix.cpp#L555

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine-tdx/40)
<!-- Reviewable:end -->
