### PR TITLE
[PAL/TDX] Emulate hypervisor-specific CPUID leaves as all-zeros

### DIFF
--- a/pal/src/host/tdx/vm_callbacks.c
+++ b/pal/src/host/tdx/vm_callbacks.c
@@ -369,6 +369,11 @@ int vm_virtualization_exception(struct isr_regs* regs) {
                 regs->rax = regs->rbx = regs->rcx = regs->rdx = 0x00000000;
                 regs->rip += vmexit_instr_length;
                 return 0;
+            } else if (regs->rax >= 0x40000000 && regs->rax <= 0x40010000) {
+                /* hypervisor-specific leaves -- return all zeros (i.e. no hypervisor) */
+                regs->rax = regs->rbx = regs->rcx = regs->rdx = 0x00000000;
+                regs->rip += vmexit_instr_length;
+                return 0;
             } else if (regs->rax == 0x80000002) {
                 /*
                  * Processor Brand String -- we hard-code rather dummy string, see below.


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Some workloads like Java query hypervisor-specific CPUID leaves 0x40000000 - 0x40010000. This commit adds emulation of these leaves as all-zeros (i.e., no hypervisor detected).

Detected on Java workload, see https://github.com/openjdk/jdk/blob/jdk-17%2B35/src/hotspot/cpu/x86/vm_version_x86.cpp#L1858

## How to test this PR? <!-- (if applicable) -->

Java.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine-tdx/41)
<!-- Reviewable:end -->
