### PR TITLE
[PAL/vm-common] Check the "break" variable less frequently in `delay()`

### DIFF
--- a/pal/src/host/vm-common/kernel_time.c
+++ b/pal/src/host/vm-common/kernel_time.c
@@ -58,9 +58,14 @@ int delay(uint64_t delay_us, bool* continue_gate) {
     uint64_t curr_tsc = get_tsc();
     uint64_t wait_until_tsc = curr_tsc + delay_us * g_tsc_mhz;
 
+    uint64_t next_gate_check_tsc = curr_tsc + 1000 * g_tsc_mhz; /* check every 1ms */
+
     while (curr_tsc < wait_until_tsc) {
-        if (continue_gate && __atomic_load_n(continue_gate, __ATOMIC_ACQUIRE))
-            break;
+        if (curr_tsc > next_gate_check_tsc) {
+            if (continue_gate && __atomic_load_n(continue_gate, __ATOMIC_ACQUIRE))
+                break;
+            next_gate_check_tsc = curr_tsc + 1000 * g_tsc_mhz;
+        }
         CPU_RELAX();
         curr_tsc = get_tsc();
     }


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, `delay()` function accessed the "break out of loop early" variable `continue_gate` basically on every CPU cycle. This variable is typically a global variable causing high contention on multi-core workloads. This e.g. manifested in the Candle Quantized LLaMA app.

This PR fixes this by checking the variable less frequently. The current heuristic is to check it every 1 ms.

## How to test this PR? <!-- (if applicable) -->

Run the Candle example; it shows better scalability.

TODO: Run other benchmarks to see if they are also ok.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine-tdx/42)
<!-- Reviewable:end -->
