### PR TITLE
[tools] Fix QEMU args in gramine-vm.in for Ubuntu 24.04

### DIFF
--- a/tools/gramine-vm.in
+++ b/tools/gramine-vm.in
@@ -92,7 +92,7 @@ QEMU_PATH="qemu"
 QEMU_VM="-cpu host,host-phys-bits,-kvm-steal-time,pmu=off,+tsc-deadline,+invtsc \
     -m $QEMU_MEM_SIZE -smp $QEMU_CPU_NUM"
 QEMU_OPTS="-enable-kvm -vga none -display none -no-reboot -monitor none \
-    -object memory-backend-memfd,id=mem,size=$QEMU_MEM_SIZE,private=on \
+    -object memory-backend-memfd,id=mem,size=$QEMU_MEM_SIZE,share=on \
     -M memory-backend=mem,hpet=off"
 
 if [ "$TDSHIM_PAL_PATH" == "" ]; then
@@ -100,7 +100,7 @@ QEMU_MACHINE="-M q35,kernel_irqchip=split"
 QEMU_BINARIES="-kernel $LIBPAL_PATH -device loader,file=$BIOS_PATH"
 else
 QEMU_MACHINE="-M q35,kernel_irqchip=split,confidential-guest-support=tdx \
-    -object tdx-guest,id=tdx,quote-generation-service=vsock:2:4050"
+    -object {\"qom-type\":\"tdx-guest\",\"id\":\"tdx\",\"quote-generation-socket\":{\"type\":\"vsock\",\"cid\":\"2\",\"port\":\"4050\"}}"
 QEMU_BINARIES="-bios $TDSHIM_PAL_PATH"
 fi
 


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
Continues and supersedes #35 

**Updated QEMU configuration for compatibility with latest version 8.2.2 on Ubuntu 24.04:**

- Replaced deprecated flag: Changed `quote-generation-service` to `quote-generation-socket`

- `virtiofsd` compatibility: `share=on` flag is added. Old `private=on` flag is not needed anymore. [official run_td script](https://github.com/canonical/tdx/blob/65e662f1b0957544379ba0ca75d287cf73d62123/guest-tools/run_td#L102)

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

Follow the latest guideline to setup the host OS and run `gramine-tdx` and `gramine-vm`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine-tdx/47)
<!-- Reviewable:end -->
