### PR TITLE
[meson] Make TD-shim path configurable

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -33,6 +33,10 @@ option('sgx_driver_include_path', type: 'string',
 option('sgx_driver_device', type: 'string',
     description: 'Path to "enclave" device in /dev (default value depends on sgx_driver)')
 
+option('tdshim_path', type: 'string',
+    value: '$HOME/td-shim',
+    description: 'Path to TD-shim root directory (default: $HOME/td-shim)')
+
 option('syslibdir', type: 'string',
     description: 'Path to the system library directory')
 

--- a/pal/src/host/tdx/meson.build
+++ b/pal/src/host/tdx/meson.build
@@ -100,13 +100,26 @@ libpal_tdx = executable('pal',
     install_dir: pkglibdir / 'tdx',
 )
 
-# FIXME: TD-shim should be installed somewhere global
 meson.add_install_script('/bin/sh', '-c',
-    ('cd "$HOME"/td-shim && cargo run -p td-shim-tools --bin td-shim-ld -- ' +
-     'target/x86_64-unknown-none/release/ResetVector.bin ' +
-     'target/x86_64-unknown-none/release/td-shim ' +
-     '-t executable -p "$MESON_INSTALL_DESTDIR_PREFIX"/@0@/gramine/tdx/pal ' +
-     '-o "$MESON_INSTALL_DESTDIR_PREFIX"/@0@/gramine/tdx/tdshim-pal').format(get_option('libdir')))
+    ('tdshim="@0@"; ' +
+     'if [ ! -d "$tdshim" ]; then ' +
+         'echo "ERROR: TD-shim path not found: $tdshim"; ' +
+         'echo "Set -Dtdshim_path to the TD-shim repo root."; ' +
+         'exit 1; ' +
+     'fi; ' +
+     'rv="$tdshim/target/x86_64-unknown-none/release/ResetVector.bin"; ' +
+     'shim="$tdshim/target/x86_64-unknown-none/release/td-shim"; ' +
+     'if [ ! -f "$rv" ] || [ ! -f "$shim" ]; then ' +
+         'echo "ERROR: TD-shim artifacts not found (expected $rv and $shim)."; ' +
+         'echo "Build TD-shim first."; ' +
+         'exit 1; ' +
+     'fi; ' +
+     'cd "$tdshim" && cargo run -p td-shim-tools --bin td-shim-ld -- ' +
+     '"$rv" "$shim" ' +
+     '-t executable -p "$MESON_INSTALL_DESTDIR_PREFIX"/@1@/gramine/tdx/pal ' +
+     '-o "$MESON_INSTALL_DESTDIR_PREFIX"/@1@/gramine/tdx/tdshim-pal')
+     .format(get_option('tdshim_path'), get_option('libdir'))
+)
 
 libpal_tdx_dep = declare_dependency(
     link_with: libpal_tdx,


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->
The TD-shim path was hardcoded to `"$HOME/td-shim"`, which breaks in containerized CI environments where `$HOME` may be unwritable or absent.

This PR introduces a Meson option `tdshim_path` and use it in the install step. The default remains `"$HOME/td-shim"`.

Example:
`-Dtdshim_path="/opt/td-shim"`

## How to test this PR? <!-- (if applicable) -->
Run `meson setup -Dtdshim_path=""` with a custom path other than `$HOME/td-shim`. 
The install script will `cd` to the custom td-shim directory and build.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine-tdx/52)
<!-- Reviewable:end -->
