### PR TITLE
[PAL/VM-COMMON/VM/TDX] Restrict PAL binary page W^X permissions

### DIFF
--- a/pal/src/host/tdx/pal_main.c
+++ b/pal/src/host/tdx/pal_main.c
@@ -261,9 +261,6 @@ noreturn void pal_start_c(void* hob_addr, void* this_addr) {
         INIT_FAIL("Failed to initialize preloaded ranges");
 
     /* memory_pagetables_init() marked all pages as RWX, now is good time to revert to NONE. */
-    /* FIXME: whole PAL binary is RWX because memory_pagetables_init() marked everything as RWX and
-     *        prot_none_memory() does *not* modify perms for PAL binary memory pages since it is
-     *        part of "preloaded ranges" */
     prot_none_memory();
 
     ret = shared_memory_init(gpa_width);

--- a/pal/src/host/vm-common/kernel_memory.c
+++ b/pal/src/host/vm-common/kernel_memory.c
@@ -513,6 +513,35 @@ __attribute_no_sanitize_address
 int memory_tighten_permissions(void) {
     int ret;
 
+    /* Linker-provided symbols for PAL kernel memory layout */
+    extern char __text_start, __text_end;
+    extern char __data_start, __data_end;
+    
+    /*
+     * PAL binary W^X (Write XOR Execute) enforcement:
+     * - Data segment [__data_start, __data_end): RW- (read-write, no execute, kernel-only)
+     * - Code segment [__text_start, __text_end): R-X (read-only, execute, kernel-only)
+     */
+    uint64_t data_start = (uint64_t)&__data_start;
+    uint64_t data_end   = (uint64_t)&__data_end;
+    uint64_t text_start = (uint64_t)&__text_start;
+    uint64_t text_end   = (uint64_t)&__text_end;
+    
+    data_end = ALIGN_UP(data_end, PAGE_SIZE);
+    text_end = ALIGN_UP(text_end, PAGE_SIZE);
+    
+    /* Enforce W^X: data segment must be writable but not executable */
+    ret = memory_mark_pages_on(data_start, data_end - data_start,
+                               /*write=*/true, /*execute=*/false, /*usermode=*/false);
+    if (ret < 0)
+        return ret;
+    
+    /* Enforce W^X: code segment must be executable but not writable */
+    ret = memory_mark_pages_on(text_start, text_end - text_start,
+                               /*write=*/false, /*execute=*/true, /*usermode=*/false);
+    if (ret < 0)
+        return ret;
+
     /*
      * [0, 1MB): Legacy DOS (includes DOS area, SMM memory, System BIOS). We could not disable these
      *           pages at PAL init, because a sub-region was used for AP multicore init code/stack.

--- a/pal/src/host/vm/pal_main.c
+++ b/pal/src/host/vm/pal_main.c
@@ -193,8 +193,6 @@ noreturn void pal_start_c(void) {
         INIT_FAIL("Failed to initialize preloaded ranges");
 
     /* PAL binary is located at 1MB and may occupy until 4MB, see pal.lds */
-    /* FIXME: whole PAL binary is RWX because memory_pagetables_init() marked everything as RWX and
-     *        zero_out_memory_and_prot_none() did *not* modify perms for PAL binary memory pages */
     ret = add_preloaded_range(0x100000UL, 0x300000UL, "pal_binary");
     if (ret < 0)
         INIT_FAIL("Failed to preload PAL-binary memory range");


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

The whole PAL binary is initialized with RWX permissions during page table setup. `prot_none_memory()` is only applied to those unused memory regions.

This PR restricts PAL memory with W^X permission.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

Regression tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine-tdx/54)
<!-- Reviewable:end -->
