### PR TITLE
Fix file mapping permissions for allowed files.

### DIFF
--- a/pal/src/host/vm-common/pal_common_files.c
+++ b/pal/src/host/vm-common/pal_common_files.c
@@ -392,7 +392,9 @@ int pal_common_file_map(struct pal_handle* handle, void* addr, pal_prot_flags_t 
     if (!handle->file.chunk_hashes) {
         /* case of allowed file */
         ret = emulate_file_map_via_read(handle->file.nodeid, handle->file.fh, addr, offset, size);
-        goto out;
+        if (ret < 0)
+            goto out;
+        goto post_map;
     }
 
     /* case of trusted file */
@@ -423,6 +425,7 @@ int pal_common_file_map(struct pal_handle* handle, void* addr, pal_prot_flags_t 
         memset((char*)addr + bytes_filled, 0, size - bytes_filled);
     }
 
+post_map:
     if (!write) {
         /* restore read-only permission */
         ret = memory_protect(addr, size, read, /*write=*/false, execute);


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

Fixed memory permissions for mapped allowed files for Gramine-VM/TDX. `host/vm-common/pal_common_files.c` is changed.

Previously, for allowed files, it would directly `goto out` after mapping the file into memory without reverting to the correct permissions. This is fixed by adding another jump label.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine-tdx/55)
<!-- Reviewable:end -->
