### PR TITLE
[PAL/vm-common] pipes: detect closed read end before write

### DIFF
--- a/pal/src/host/vm-common/pal_common_pipes.c
+++ b/pal/src/host/vm-common/pal_common_pipes.c
@@ -280,6 +280,11 @@ int64_t pal_common_pipe_write(struct pal_handle* handle, uint64_t offset, uint64
 
     spinlock_lock(&pipe_buf->lock);
 
+    if (!pipe_buf->readable) {
+        bytes = -PAL_ERROR_CONNFAILED_PIPE;
+        goto out;
+    }
+
     /* must guarantee that PIPE_BUF_SIZE bytes are written atomically (for a blocking pipe) */
     bytes = 0;
     while (bytes < (ssize_t)len) {


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->
This PR fixes a VM `vm-common` pipe bug that failed `test_libos.py::TC_30_Syscall::test_092_sighandler_sigpipe`.

Previously, `pal_common_pipe_write()` checked `!pipe_buf->readable` only in the “pipe buffer is full” path. If the peer had already closed its read end but the buffer still had space, `write()` could still succeed and copy bytes into the ring buffer. That missed the expected broken-pipe behavior (`EPIPE`/`SIGPIPE`).

This PR adds an early `!pipe_buf->readable` check in `pal_common_pipe_write()` before copying any bytes, so writes fail immediately when no read end is open.

## How to test this PR? <!-- (if applicable) -->
**test_libos.py::TC_30_Syscall::test_092_sighandler_sigpipe**
Before:
```sh
$  gramine-test pytest -vv -s test_libos.py::TC_30_Syscall::test_092_sighandler_sigpipe
Got 0 SIGPIPE signal(s)
[ VM exited with code 0 ]
```
Expected:
```sh
$  gramine-test pytest -vv -s test_libos.py::TC_30_Syscall::test_092_sighandler_sigpipe
Could not write to pipe: Broken pipe
Got signal 13
Got 1 SIGPIPE signal(s)
[ VM exited with code 141 ]

```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine-tdx/59)
<!-- Reviewable:end -->
