### PR TITLE
[PAL/vm-common] Query file attrs by nodeid

### DIFF
--- a/pal/src/host/vm-common/pal_common.h
+++ b/pal/src/host/vm-common/pal_common.h
@@ -62,6 +62,7 @@ int pal_common_file_map(struct pal_handle* handle, void* addr, pal_prot_flags_t 
 int pal_common_file_setlength(struct pal_handle* handle, uint64_t length);
 int pal_common_file_flush(struct pal_handle* handle);
 int pal_common_file_attrquerybyhdl(struct pal_handle* handle, PAL_STREAM_ATTR* pal_attr);
+int pal_common_file_attrquerybynodeid(uint64_t nodeid, uint32_t flags, PAL_STREAM_ATTR* pal_attr);
 int pal_common_file_attrquery(const char* type, const char* uri, PAL_STREAM_ATTR* pal_attr);
 int pal_common_file_attrsetbyhdl(struct pal_handle* handle, PAL_STREAM_ATTR* attr);
 int pal_common_file_rename(struct pal_handle* handle, const char* type, const char* uri);

--- a/pal/src/host/vm-common/pal_common_files.c
+++ b/pal/src/host/vm-common/pal_common_files.c
@@ -466,21 +466,42 @@ int pal_common_file_attrquerybyhdl(struct pal_handle* handle, PAL_STREAM_ATTR* p
     return 0;
 }
 
+int pal_common_file_attrquerybynodeid(uint64_t nodeid, uint32_t flags, PAL_STREAM_ATTR* pal_attr) {
+    int ret;
+    assert(!(flags & FUSE_GETATTR_FH));
+
+    struct fuse_attr attr;
+    ret = virtio_fs_fuse_getattr(nodeid, 0, flags, UINT64_MAX, &attr);
+    if (ret < 0)
+        return ret;
+
+    pal_attr->handle_type  = S_ISREG(attr.mode) ? PAL_TYPE_FILE : PAL_TYPE_DIR;
+    pal_attr->share_flags  = attr.mode & PAL_SHARE_MASK;
+    pal_attr->pending_size = attr.size;
+    pal_attr->nonblocking  = false;
+    return 0;
+}
+
 int pal_common_file_attrquery(const char* type, const char* uri, PAL_STREAM_ATTR* pal_attr) {
     if (strcmp(type, URI_TYPE_FILE) && strcmp(type, URI_TYPE_DIR))
         return -PAL_ERROR_INVAL;
 
     int ret;
+    char* resolved_path = NULL;
 
-    struct pal_handle* hdl = NULL;
-    ret = pal_common_file_open(&hdl, type, uri, PAL_ACCESS_RDONLY, /*share_flags=*/0,
-                               PAL_CREATE_NEVER, PAL_OPTION_PASSTHROUGH);
+    ret = realpath(uri, /*got_path=*/NULL, &resolved_path);
     if (ret < 0)
         return ret;
+    uint64_t nodeid;
+    ret = virtio_fs_fuse_lookup(resolved_path, &nodeid);
+    if (ret < 0) {
+        free(resolved_path);
+        return ret;
+    }
 
-    ret = pal_common_file_attrquerybyhdl(hdl, pal_attr);
+    ret = pal_common_file_attrquerybynodeid(nodeid, 0, pal_attr);
 
-    pal_common_file_destroy(hdl);
+    free(resolved_path);
     return ret;
 }
 


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

Previously, `pal_common_file_attrquery()` opened the target first and then queried its attributes by handle.

This forced attribute queries through the open path, which is unnecessary for lookup and can fail early on unsupported special files. 
For example, for socket entries, `virtio_fs_fuse_open()` could fail with `EBADF` (mapped to `PAL_ERROR_BADHANDLE`), which caused regressions in `test_pal.py::TC_20_SingleProcess::test_110_directory` and `test_libos.py::TC_30_Syscall::test_023_readdir`.

This PR adds `pal_common_file_attrquerybynodeid()` and switches `pal_common_file_attrquery()` to use the nodeid-based `FUSE_GETATTR` path instead of opening the target first.

## How to test this PR? <!-- (if applicable) -->
**test_pal.py::TC_20_SingleProcess::test_110_directory**
Before:
```sh
$ gramine-test --sgx pytest -vv -s test_pal.py::TC_20_SingleProcess::test_110_directory
test_pal.py::TC_20_SingleProcess::test_110_directory FAILED
...
[7.927] Directory Open Test 2 OK
[7.927] Directory Open Test 3 OK
[7.927] Directory Creation Test 1 OK
[7.927] Directory Creation Test 2 OK
[7.927] Directory Creation Test 3 OK
[7.927] (pal_process.c:16:_PalProcessExit) [ VM exited with code 0 ]
```

After:
```sh
$ gramine-test --sgx pytest -vv -s test_pal.py::TC_20_SingleProcess::test_110_directory
test_pal.py::TC_20_SingleProcess::test_110_directory [4.476] Directory Open Test 1 OK
...
[4.477] Directory Open Test 2 OK
[4.477] Directory Open Test 3 OK
[4.477] Query: type = 6
[4.477] Directory Creation Test 1 OK
[4.477] Directory Creation Test 2 OK
[4.478] Directory Creation Test 3 OK
[4.481] (pal_process.c:16:_PalProcessExit) [ VM exited with code 0 ]
```
**test_libos.py::TC_30_Syscall::test_023_readdir**
Before:
```sh
$ gramine-test pytest -vv -s test_libos.py::TC_30_Syscall::test_023_readdir
[4.574] readdir failed: Bad file descriptor
[4.574] readdir failed: Bad file descriptor
[4.574] file __testfile__ was not found: Bad file descriptor
[4.576] [ VM exited with code 1 ]
```

After:
```sh
$ gramine-test pytest -vv -s test_libos.py::TC_30_Syscall::test_023_readdir
test_libos.py::TC_30_Syscall::test_023_readdir [4.746] test completed successfully
[4.746] [ VM exited with code 0 ]
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine-tdx/60)
<!-- Reviewable:end -->
