### PR TITLE
[LibOS,meson] Use `syscall` instruction path for VM/TDX in gramine_entry_api and vDSO

### DIFF
--- a/libos/include/arch/x86_64/gramine_entry_api.h
+++ b/libos/include/arch/x86_64/gramine_entry_api.h
@@ -52,7 +52,11 @@ __attribute__((naked)) static int gramine_call(int number __attribute__((unused)
                                                unsigned long arg2 __attribute__((unused))) {
     __asm__ (
         "mov $" GRAMINE_XSTR(GRAMINE_CUSTOM_SYSCALL_NR) ", %eax\n"
+#ifdef GRAMINE_CALL_USE_SYSCALL_INSTR
+        "syscall\n"
+#else
         "GRAMINE_SYSCALL\n"
+#endif
         "ret\n"
     );
 }

--- a/libos/src/vdso/arch/x86_64/meson.build
+++ b/libos/src/vdso/arch/x86_64/meson.build
@@ -4,7 +4,7 @@ c_vdso_args = [
     '-ffreestanding',
 ]
 
-if vm
+if vm or tdx
     c_vdso_args += ['-DVDSO_USE_SYSCALL_INSTR']
 endif
 

--- a/libos/test/regression/test_libos.py
+++ b/libos/test/regression/test_libos.py
@@ -847,9 +847,6 @@ class TC_30_Syscall(RegressionTestCase):
         # Futex Wake Test
         self.assertIn('Woke all kiddos', stdout)
 
-    @unittest.skipIf(HAS_TDX,
-        "TODO: re-enable after TDX builds include the vDSO "
-        "(see https://github.com/gramineproject/gramine-tdx/pull/61)")
     def test_041_futex_timeout(self):
         stdout, _ = self.run_binary(['futex_timeout'])
 
@@ -1085,9 +1082,6 @@ class TC_30_Syscall(RegressionTestCase):
         stdout, _ = self.run_binary(['pthread_set_get_affinity', '1000'])
         self.assertIn('TEST OK', stdout)
 
-    @unittest.skipIf(HAS_TDX,
-        "TODO: re-enable after TDX builds include the vDSO "
-        "(see https://github.com/gramineproject/gramine-tdx/pull/61)")
     def test_103_gettimeofday(self):
         stdout, _ = self.run_binary(['gettimeofday'])
         self.assertIn('TEST OK', stdout)

--- a/libos/test/regression/test_libos.py
+++ b/libos/test/regression/test_libos.py
@@ -32,9 +32,6 @@ class TC_00_Unittests(RegressionTestCase):
         stdout, _ = self.run_binary(['spinlock'], timeout=20)
         self.assertIn('Test successful!', stdout)
 
-    @unittest.skipIf(HAS_TDX or HAS_VM,
-        "TODO: re-enable after gramine_call() uses the syscall instruction path in VM/TDX builds "
-        "(see https://github.com/gramineproject/gramine-tdx/pull/61)")
     def test_001_rwlock(self):
         # You may need to adjust sgx.max_threads in the manifest when changing these
         instances = 5
@@ -46,9 +43,6 @@ class TC_00_Unittests(RegressionTestCase):
                                      str(writers_num), str(writers_delay_us)], timeout=45)
         self.assertIn('TEST OK', stdout)
 
-    @unittest.skipIf(HAS_TDX or HAS_VM,
-        "TODO: re-enable after gramine_call() uses the syscall instruction path in VM/TDX builds "
-        "(see https://github.com/gramineproject/gramine-tdx/pull/61)")
     def test_010_gramine_run_test(self):
         stdout, _ = self.run_binary(['run_test', 'pass'])
         self.assertIn('gramine_run_test("pass") = 0', stdout)

--- a/meson.build
+++ b/meson.build
@@ -167,6 +167,10 @@ if vm and host_machine.cpu_family() != 'x86_64'
     error('VM PAL is currently available only for x86-64 arch')
 endif
 
+if vm or tdx
+    add_project_arguments('-DGRAMINE_CALL_USE_SYSCALL_INSTR', language: ['c'])
+endif
+
 gen_symbol_map_cmd = [
     find_program('nm'),
     '--numeric-sort', '--defined-only', '--print-size', '--line-numbers',


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->
Previously, `gramine_entry_api` did not use the `syscall` instruction and always jumped via `%gs:GRAMINE_SYSCALL_OFFSET`. In VM/TDX configurations, where LibOS and PAL run at ring 0, this could lead to memory faults.

Also, existing `VDSO_USE_SYSCALL_INSTR` was enabled only for `vm`, so TDX-only builds did not use the vDSO syscall path.

This PR:
- enables `GRAMINE_ENTRY_USE_SYSCALL_INSTR` for both `vm` and `tdx`, so `gramine_entry_api` uses `syscall`;
- enables `VDSO_USE_SYSCALL_INSTR` for both `vm` and `tdx`.

Related regression failures:

vDSO:
- `test_libos.py::TC_30_Syscall::test_041_futex_timeout`
- `test_libos.py::TC_30_Syscall::test_103_gettimeofday`

gramine_entry_api:
- `test_libos.py::TC_00_Unittests::test_001_rwlock`
- `test_libos.py::TC_00_Unittests::test_010_gramine_run_test`

## How to test this PR? <!-- (if applicable) -->
Before:
```sh
Internal memory fault with VMA at 0x3df75ef9 (0x3df75ef9, VMID = 1, TID = 1)
[11.989] [ VM exited with code 1 ]
```

After:
No internal memory fault in this path.
The regression tests listed above now pass.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine-tdx/61)
<!-- Reviewable:end -->
