### PR TITLE
[PAL/vm-common,tools] Support quoted and escaped args/envs in fw_cfg

### DIFF
--- a/pal/src/host/vm-common/kernel_vmm_inputs.c
+++ b/pal/src/host/vm-common/kernel_vmm_inputs.c
@@ -23,11 +23,38 @@ char g_host_pwd[PATH_MAX];
 char g_cmdline[MAX_ARGV_SIZE];
 char g_envs[MAX_ENVS_SIZE];
 
+static int cmdline_read_escaped_token(char** p_ptr) {
+    char* read_ptr = *p_ptr;
+    char* write_ptr = read_ptr;
+
+    while (true) {
+        if (*read_ptr == '\0')
+            return -PAL_ERROR_INVAL;
+
+        if (*read_ptr == '"') {
+            *write_ptr = '\0';
+            *p_ptr = read_ptr + 1;
+            if (**p_ptr != ' ')
+                return -PAL_ERROR_INVAL;
+            return 0;
+        }
+
+        if (*read_ptr == '\\') {
+            read_ptr++;
+            if (*read_ptr != '"' && *read_ptr != '\\')
+                return -PAL_ERROR_INVAL;
+        }
+
+        *write_ptr++ = *read_ptr++;
+    }
+}
+
 /* This function copies `input` to a new string (we don't want to modify `input`) and splits the
- * new line in NUL-terminated sub-strings (arguments). Each argument may be enclosed in
- * double-quotes; in this case everything between the double-quotes (including whitespaces) is
- * considered as one argument. Having an argument without a closing double-quote leads to error. No
- * escaping is supported (e.g., `\"` is not allowed). */
+ * new line into NUL-terminated sub-strings (arguments). Each argument must be enclosed in
+ * double-quotes; everything between the double-quotes (including whitespaces) is considered one
+ * argument. Inside a quoted argument, only `\"` and `\\` escapes are supported. Parsing stops at
+ * the unquoted `end_str` marker; malformed quoting, unsupported escapes, or a missing end marker
+ * lead to error. */
 static int cmdline_read_common(enum cmdline_parse_type type, const char* input, int* out_cnt,
                                const char** out_array) {
     /* Choose the appropriate starting and ending string as well as the max token size for
@@ -64,49 +91,39 @@ static int cmdline_read_common(enum cmdline_parse_type type, const char* input, 
         goto out;
     }
 
-    char* p_end = strstr(p, end_str);
-    if (!p_end) {
-        ret = -PAL_ERROR_INVAL;
-        goto out;
-    }
-
-    /* do not count the end_str (e.g. `-gramine-args-end`) and everything after it as arguments */
-    *p_end = '\0';
-
     p += strlen(begin_str);
-    while (p) {
-        while (*p == ' ' || *p == '\t')
+    while (true) {
+        while (*p == ' ')
             p++;
-        if (*p == '\0')
-            break;
+        if (*p == '\0') {
+            ret = -PAL_ERROR_INVAL;
+            goto out;
+        }
+
+        if (*p != '"') {
+            size_t token_len = 0;
+            while (p[token_len] != '\0')
+                token_len++;
+            if (token_len == strlen(end_str) && memcmp(p, end_str, token_len) == 0) {
+                p += token_len;
+                break;
+            }
+            ret = -PAL_ERROR_INVAL;
+            goto out;
+        }
 
         if (curr_cnt == max_tokens) {
             ret = -PAL_ERROR_NOMEM;
             goto out;
         }
 
-        bool token_in_double_quotes = false;
-        if (*p == '"') {
-            p++;
-            token_in_double_quotes = true;
-        }
 
-        out_array[curr_cnt] = p;
+        out_array[curr_cnt] = ++p;
         curr_cnt++;
 
-        if (token_in_double_quotes) {
-            while (*p != '\0' && *p != '"')
-                p++;
-            if (*p == '\0') {
-                ret = -PAL_ERROR_INVAL;
-                goto out;
-            }
-            *p++ = '\0'; /* replace closing double-quote with NUL */
-        } else {
-            while (*p != '\0' && *p != ' ' && *p != '\t')
-                p++;
-            *p++ = '\0'; /* replace whitespace with NUL */
-        }
+        ret = cmdline_read_escaped_token(&p);
+        if (ret < 0)
+            goto out;
     }
 
     /* items of out_array point into `input_copy` buffer */

--- a/pal/src/host/vm-common/kernel_vmm_inputs.h
+++ b/pal/src/host/vm-common/kernel_vmm_inputs.h
@@ -26,9 +26,10 @@
  *   - wiki.osdev.org/QEMU_fw_cfg
  *
  * The arguments must be in the following format:
- *    "-gramine-args init argv0 argv1 ... -gramine-args-end"
-  * The environment variables must be in the following format:
+ *    "-gramine-args "init" "argv0" "argv1" ... -gramine-args-end"
+ * The environment variables must be in the following format:
  *    "-gramine-envs "KEY1=VAL1" "KEY2=VAL2" ... -gramine-envs-end"
+ * Double-quoted items support escaping `"` and `\` as `\"` and `\\`.
  */
 
 #pragma once

--- a/tools/gramine-vm.in
+++ b/tools/gramine-vm.in
@@ -157,17 +157,37 @@ QEMU_VIRTIO_FS="-chardev socket,path=/tmp/gramine_vhostfs_"$GRAMINE_VM_ID",id=vh
 QEMU_VIRTIO_VSOCK="-device vhost-vsock-pci,iommu_platform=off,guest-cid="$GRAMINE_VM_ID",id=vsockdev"
 
 # Due to QEMU syntax, commas in the QEMU cmdline need to be escaped using an additional comma.
-APPLICATION=${APPLICATION//","/",,"}
-GRAMINE_ARGS="-gramine-args init \"$APPLICATION\" $@ -gramine-args-end"
-
-GRAMINE_ENVS=$(python3 -c "
+gramine_vars="$(python3 - "$APPLICATION" "$@" <<'PY'
 import os
-env_str = ''
-for name, value in os.environ.items():
-    env_str += ('\"{0}={1}\" '.format(name, value).replace(',', ',,'))
-print(env_str)
-")
-GRAMINE_ENVS="-gramine-envs $GRAMINE_ENVS -gramine-envs-end"
+import shlex
+import sys
+
+def serialize_item(item):
+    escaped = item.replace('\\', '\\\\').replace('"', '\\"').replace(',', ',,')
+    return f'"{escaped}"'
+
+gramine_args = (
+    '-gramine-args '
+    f"{' '.join(serialize_item(arg) for arg in ['init'] + sys.argv[1:])} "
+    '-gramine-args-end'
+)
+
+gramine_envs = (
+    '-gramine-envs '
+    f"{' '.join(serialize_item(f'{k}={v}') for k, v in os.environ.items())} "
+    '-gramine-envs-end'
+)
+
+print(f"GRAMINE_ARGS={shlex.quote(gramine_args)}")
+print(f"GRAMINE_ENVS={shlex.quote(gramine_envs)}")
+PY
+)"
+EXIT_STATUS=$?
+if [ $EXIT_STATUS -ne 0 ]; then
+    echo "Error: Python script for serializing args/envs exited with status: $EXIT_STATUS"
+    exit $EXIT_STATUS
+fi
+eval "$gramine_vars"
 
 CMD=("${ENVS[@]}")
 CMD+=("${PREFIX[@]}")


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

Fixes #63.

Previously, `gramine-args/envs` did not support escaping. Gramine args were flattened, and env entries could not contain `"` because an embedded quote terminated the item early. As a result, args could not contain spaces, and env values could not contain double quotes.

Switch `gramine-args/envs` to a quoted-item format:
```
  -gramine-args "arg" ... -gramine-args-end
  -gramine-envs "env" ... -gramine-envs-end
```
Update the PAL parser and `gramine-vm` serializer to support `\"` and `\\` inside quoted items.

## How to test this PR? <!-- (if applicable) -->
Before:
```
# Testing arg boundary preservation
$ gramine-vm bootstrap 'a b c' d
...
# of arguments: 5
argv[0] = bootstrap
argv[1] = a
argv[2] = b
argv[3] = c
argv[4] = d
...

# Testing arg with embedded double quote
$ gramine-vm bootstrap 'a "b c' d
error: PAL failed Failed to read Gramine arguments
[ VM exited with code 1 ]

# Testing env value with embedded double quote
$ A='A "B" C' gramine-vm env_passthrough
error: PAL failed Building the final environment based on the original environment and the manifest failed: Invalid argument (PAL_ERROR_INVAL)
[ VM exited with code 1 ]
```
After:
```
# Testing arg boundary preservation
$ gramine-vm bootstrap 'a b c' d
...
# of arguments: 3
argv[0] = bootstrap
argv[1] = a b c
argv[2] = d
...

# Testing arg with embedded double quote
$ gramine-vm bootstrap 'a "b c' d
...
# of arguments: 3
argv[0] = bootstrap
argv[1] = a "b c
argv[2] = d
...

# Testing env value with embedded double quote
$ A='A "B" C' gramine-vm env_passthrough
...
# of envs: 3
envp[0] = A=A "B" C
envp[1] = LD_LIBRARY_PATH=/lib
envp[2] = B=OVERWRITTEN_VALUE
...
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine-tdx/65)
<!-- Reviewable:end -->
