### PR TITLE
[CI] Enable VM GDB regression testing

### DIFF
--- a/libos/test/regression/debug_vm.gdb
+++ b/libos/test/regression/debug_vm.gdb
@@ -1,0 +1,27 @@
+set breakpoint pending on
+set pagination off
+set backtrace past-main on
+
+# Check if debug sources are loaded in our program, and we can break inside.
+
+hbreak func
+commands
+  echo \n<backtrace 1 start>\n
+  backtrace
+  echo <backtrace 1 end>\n\n
+
+  # Check if we can break inside PAL. On VM, backtracing currently stops inside PAL,
+  # so this backtrace is expected to show PAL frames only.
+
+  hbreak pal_common_console_write
+  commands
+    echo \n<backtrace 2 start>\n
+    backtrace
+    echo <backtrace 2 end>\n\n
+    continue
+  end
+
+  continue
+end
+
+continue

--- a/libos/test/regression/test_libos.py
+++ b/libos/test/regression/test_libos.py
@@ -1352,14 +1352,44 @@ class TC_50_GDB(RegressionTestCase):
 
     def test_000_gdb_backtrace(self):
         # To run this test manually, use:
-        # GDB=1 GDB_SCRIPT=debug.gdb gramine-{direct|sgx} debug
+        # Direct/SGX:
+        #   GDB=1 GDB_SCRIPT=debug.gdb gramine-{direct|sgx} debug
+        # VM (two terminals):
+        #   In the first terminal, launch gramine-vm with GDB enabled:
+        #     GDB=1 gramine-vm debug
+        #   In the second terminal, first get the debug binary's `.text` address:
+        #     APP_TEXT_ADDR=$(objdump -h /path/to/debug | awk '$2 == ".text" { print "0x" $4 }')
+        #   Then launch gdb:
+        #     gdb \
+        #         -ex "file /path/to/vm/pal" \
+        #         -ex "target remote localhost:9000" \
+        #         -ex "add-symbol-file /path/to/debug $APP_TEXT_ADDR" \
+        #         -x debug_vm.gdb \
+        #         -batch \
+        #         -tty=/dev/null
+        # TDX: currently unsupported.
         #
         # TODO: strengthen this test after SGX includes enclave entry.
         #
         # While the stack trace in SGX is unbroken, it currently starts at _start inside
         # enclave, instead of including eclave entry.
 
-        stdout, _ = self.run_gdb(['debug'], 'debug.gdb')
+        gdb_script = 'debug_vm.gdb' if HAS_VM else 'debug.gdb'
+        stdout, _ = self.run_gdb(['debug'], gdb_script)
+
+        if HAS_VM:
+            # TODO: VM PAL does not yet implement debug_map for runtime-loaded libraries, so
+            # backtrace checks across libc do not work on VM:
+            # https://github.com/gramineproject/gramine-tdx/issues/67
+            backtrace_1 = self.find('backtrace 1', stdout)
+            self.assertIn(' func ()', backtrace_1)
+            self.assertIn(' main ()', backtrace_1)
+            self.assertIn('debug.c', backtrace_1)
+
+            backtrace_2 = self.find('backtrace 2', stdout)
+            self.assertIn(' pal_common_console_write (', backtrace_2)
+            self.assertIn('pal_common_console.c', backtrace_2)
+            return
 
         backtrace_1 = self.find('backtrace 1', stdout)
         self.assertIn(' main ()', backtrace_1)

--- a/python/graminelibos/regression.py
+++ b/python/graminelibos/regression.py
@@ -163,6 +163,39 @@ def run_command(cmd, *, timeout, open_fds_limit=None, can_fail=False, **kwds):
 
         return main_returncode, stdout, stderr
 
+def wait_for_vm_gdbstub(host, port, deadline, proc=None):
+    while True:
+        if proc is not None:
+            proc.poll()
+            if proc.returncode is not None:
+                return False
+
+        remaining = deadline - time.time()
+        if remaining <= 0:
+            return False
+
+        try:
+            with socket.create_connection((host, port), timeout=min(0.5, remaining)):
+                return True
+        except OSError:
+            time.sleep(min(0.1, remaining))
+
+def get_elf_section_addr(path, section_name):
+    try:
+        from elftools.elf.elffile import ELFFile
+    except ImportError:
+        print(
+            'Python elftools module not found, please install (e.g. apt install python3-pyelftools)'
+        )
+        raise
+
+    with open(path, 'rb') as f:
+        elf = ELFFile(f)
+        section = elf.get_section_by_name(section_name)
+
+    if section is None:
+        raise ValueError(f'section {section_name} not found in {path}')
+    return int(section.header['sh_addr'])
 
 class RegressionTestCase(unittest.TestCase):
     DEFAULT_TIMEOUT = (20 if HAS_SGX else 10)
@@ -193,6 +226,10 @@ class RegressionTestCase(unittest.TestCase):
         return '.debug_info' in dump
 
     def run_gdb(self, args, gdb_script, **kwds):
+        if HAS_VM:
+            return self.run_gdb_vm(args, gdb_script, **kwds)
+        elif HAS_TDX:
+            self.fail('GDB is currently not supported in TDX PAL')
         prefix = ['gdb', '-q']
         env = os.environ.copy()
         if HAS_SGX:
@@ -207,6 +244,102 @@ class RegressionTestCase(unittest.TestCase):
         prefix += ['--args']
 
         return self.run_binary(args, prefix=prefix, env=env, **kwds)
+
+    def run_gdb_vm(self, args, gdb_script, *, timeout=None, **kwds):
+        timeout = (max(self.DEFAULT_TIMEOUT, timeout) if timeout is not None
+                   else self.DEFAULT_TIMEOUT)
+        deadline = time.time() + timeout
+        gdb_port = 9000
+        env = kwds.get('env')
+        cmd, gramine_vm_id = self.build_vm_command(
+            args, prefix=None, run_gdb=True, env=env, gdb_port=gdb_port)
+
+        open_fds_limit = kwds.pop('open_fds_limit', None)
+        gdb_stdout = ''
+        gdb_stderr = ''
+        gdb_returncode = 0
+        gdb_wrapper_path = None
+
+        with tempfile.TemporaryFile() as vm_stdout_file, tempfile.TemporaryFile() as vm_stderr_file:
+            vm_proc = subprocess.Popen(
+                cmd,
+                stdout=vm_stdout_file,
+                stderr=vm_stderr_file,
+                preexec_fn=lambda: set_open_fds_limit(open_fds_limit),
+                start_new_session=True,
+                **kwds,
+            )
+            try:
+                if not wait_for_vm_gdbstub('127.0.0.1', gdb_port, deadline, proc=vm_proc):
+                    raise AssertionError(
+                        f'VM gdb stub on port {gdb_port} did not become ready before the VM exited')
+
+                with tempfile.NamedTemporaryFile(
+                        mode='w', encoding='utf-8', suffix='.gdb', delete=False) as gdb_wrapper:
+                    gdb_wrapper.write('set confirm off\n')
+                    gdb_wrapper.write(f'file {fspath(self.libpal_vm_path)}\n')
+                    gdb_wrapper.write(f'target remote 127.0.0.1:{gdb_port}\n')
+                    app_binary = (pathlib.Path(graminelibos._CONFIG_PKGLIBDIR) / 'tests' /
+                                  'libos' / 'regression' / args[0])
+                    app_text_addr = get_elf_section_addr(app_binary, '.text')
+                    gdb_wrapper.write(
+                        f'add-symbol-file {fspath(app_binary)} 0x{app_text_addr:x}\n')
+                    gdb_wrapper.write(f'source {gdb_script}\n')
+                    gdb_wrapper_path = gdb_wrapper.name
+
+                time_remaining = deadline - time.time()
+
+                gdb_cmd = ['gdb', '-q', '-x', gdb_wrapper_path, '-batch', '-tty=/dev/null']
+                gdb_returncode, gdb_stdout, gdb_stderr = run_command(
+                    gdb_cmd, timeout=time_remaining, can_fail=True)
+
+                time_remaining = deadline - time.time()
+                if time_remaining <= 0:
+                    raise AssertionError(f'Command {args} timed out after {timeout} s')
+
+                vm_proc.wait(time_remaining)
+            except subprocess.TimeoutExpired as e:
+                raise AssertionError(f'Command {args} timed out after {timeout} s') from e
+            finally:
+                if gdb_wrapper_path is not None:
+                    try:
+                        os.unlink(gdb_wrapper_path)
+                    except FileNotFoundError:
+                        pass
+
+                try:
+                    os.killpg(vm_proc.pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+                try:
+                    vm_proc.wait(timeout=1)
+                except subprocess.TimeoutExpired:
+                    pass
+                cleanup_vm(gramine_vm_id)
+
+            vm_stdout_file.flush()
+            vm_stdout_file.seek(0)
+            vm_stdout = vm_stdout_file.read().decode(errors='surrogateescape')
+
+            vm_stderr_file.flush()
+            vm_stderr_file.seek(0)
+            vm_stderr = vm_stderr_file.read().decode(errors='surrogateescape')
+
+        stdout = gdb_stdout + vm_stdout
+        stderr = gdb_stderr + vm_stderr
+
+        if gdb_returncode != 0:
+            raise subprocess.CalledProcessError(
+                gdb_returncode, ['gdb', '-q', '-x', gdb_script], encode_output(stdout),
+                encode_output(stderr))
+
+        guest_returncode = extract_vm_exit_code(vm_stdout, vm_stderr)
+        host_returncode = vm_proc.returncode
+        returncode = host_returncode if guest_returncode is None else guest_returncode
+        if returncode != 0:
+            raise subprocess.CalledProcessError(
+                returncode, args, encode_output(stdout), encode_output(stderr))
+        return stdout, stderr
 
     def run_binary(self, args, *, timeout=None, prefix=None, **kwds):
         timeout = (max(self.DEFAULT_TIMEOUT, timeout) if timeout is not None


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->
This PR adds `run_gdb_vm()` to run GDB regression tests on the VM PAL, introduces a VM-specific GDB script for `test_000_gdb_backtrace`, and enables that test on VM. 

It also updates the expected backtrace to account for current VM limitations.
## How to test this PR? <!-- (if applicable) -->
Run test `test_libos.py::TC_50_GDB::test_000_gdb_backtrace`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gramine-tdx/68)
<!-- Reviewable:end -->
